### PR TITLE
Fix warning about unused variable.

### DIFF
--- a/Evolve13/Evolve13/Controls/WrapLayout.cs
+++ b/Evolve13/Evolve13/Controls/WrapLayout.cs
@@ -44,7 +44,7 @@ namespace Xamarin.Forms
 
 			double lastX;
 			double lastY;
-			var layout = NaiveLayout (widthConstraint, heightConstraint, out lastX, out lastY);
+			NaiveLayout (widthConstraint, heightConstraint, out lastX, out lastY);
 
 			return new SizeRequest (new Size (lastX, lastY));
 		}


### PR DESCRIPTION
In OnSizeRequest the layout variable wasn't in use, however lastX and lastY were updated via the NaiveLayout call. This commit just removes `var layout =` to silence compiler warnings about unused variables.
