### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/OxyPlotDemo/README.md
+++ b/OxyPlotDemo/README.md
@@ -19,7 +19,7 @@ The core can be used in Xamarin.Forms and the platform-specific assemblies used 
 ![screenshot](https://github.com/conceptdev/xamarin-forms-samples/raw/master/OxyPlotDemo/Screenshots/pieseries-sml.png "Pie")
 
 
-##Simple demo
+## Simple demo
 
 This sample code to get started came from the [WPF demo](http://oxyplot.org/doc/HelloWpfXaml.html).
 
@@ -56,6 +56,6 @@ This sample code to get started came from the [WPF demo](http://oxyplot.org/doc/
 
 ![screenshot](https://github.com/conceptdev/xamarin-forms-samples/raw/master/OxyPlotDemo/Screenshots/iOS-sml.png "iOS") ![screenshot](https://github.com/conceptdev/xamarin-forms-samples/raw/master/OxyPlotDemo/Screenshots/Android-sml.png "Android") ![screenshot](https://github.com/conceptdev/xamarin-forms-samples/raw/master/OxyPlotDemo/Screenshots/WinPhone-sml.png "WinPhone")
 
-##WARNING
+## WARNING
 
 This is only an "example" - I would recommend using the [OxyPlot component](https://components.xamarin.com/view/oxyplot) or investigating commercial charting controls for Xamarin.Forms (from Telerik or others).

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Many of the Xamarin.Forms samples in this repo are discussed in **Intro_To_Xamar
 
 * **TodoXaml** - same todo list application logic, but using XAML to declaratively build the screen layouts (rather than C# code, uses SQLite.Net-PCL Nuget). 
 
-##Unfinished
+## Unfinished
 
 * **TicTacForms** - simple tic tac toe game ~ still under development...
 
@@ -56,9 +56,9 @@ Also the Azure ones, and the Parse Xamarin Store Component.
 Other Interesting Repos
 -----------------------
 
-###[XForms](https://github.com/XForms/Xamarin-Forms-Labs)
+### [XForms](https://github.com/XForms/Xamarin-Forms-Labs)
 Community-driven controls and extensions for Xamarin.Forms
 
-###[acr-xamarin-forms](https://github.com/aritchie/acr-xamarin-forms#acr-xamarin-forms)
+### [acr-xamarin-forms](https://github.com/aritchie/acr-xamarin-forms#acr-xamarin-forms)
 Another source of controls written by Allan Ritchie
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
