### PR TITLE
disregard children that IsVisible is set to false

### DIFF
--- a/Evolve13/Evolve13/Controls/WrapLayout.cs
+++ b/Evolve13/Evolve13/Controls/WrapLayout.cs
@@ -76,7 +76,7 @@ namespace Xamarin.Forms
 			var result = new List<List<Tuple<View, Rectangle>>> ();
 			var currentList = new List<Tuple<View, Rectangle>> ();
 
-			foreach (var child in Children) {
+			foreach (var child in Children.Where(c => c.IsVisible)) {
 				SizeRequest sizeRequest;
 				if (!layoutCache.TryGetValue (child, out sizeRequest)) {
 					layoutCache[child] = sizeRequest = child.GetSizeRequest (double.PositiveInfinity, double.PositiveInfinity);


### PR DESCRIPTION
Currently when using WrapLayout, any child that IsVisible is set to false is replaced by a blank space. This change disregards all children that are not visible.